### PR TITLE
Remove comma to avoid starting a new column

### DIFF
--- a/acceptance rates.csv
+++ b/acceptance rates.csv
@@ -1,5 +1,5 @@
 Venue,Date,Submitted,Accepted,Rate,Source
-InfoVis,2019,214,53,24.8%,(note: 4 desk rejects, -2+1 track changes) https://twitter.com/alexrindvis/status/1201541405186953216
+InfoVis,2019,214,53,24.8%,(note: 4 desk rejects and -2+1 track changes) https://twitter.com/alexrindvis/status/1201541405186953216
 InfoVis,2018,185,47,25.13%, (note: also 2 desk rejects)
 InfoVis,2017,170,39,22.94%,https://twitter.com/NElmqvist/status/848707760220975105
 InfoVis,2016,167,37,22.15%, VIS talk schedule


### PR DESCRIPTION
The text for the source of the 2019 entry contained a comma, which starts a new column in a CSV. This change replaces the comma with the word "and" to avoid splitting the text into a new column.